### PR TITLE
Fix track wrapping in prevTrack

### DIFF
--- a/main.js
+++ b/main.js
@@ -149,7 +149,7 @@ function nextTrack() {
 
 function prevTrack() {
   if (trackIndex > 0) trackIndex -= 1;
-  else trackIndex = trackList.length;
+  else trackIndex = trackList.length - 1;
   loadTrack(trackIndex);
   playTrack();
 }


### PR DESCRIPTION
## Summary
- ensure `prevTrack()` loops to the last track by using `trackList.length - 1`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684e500e07388321b78ba12cc0f65f89